### PR TITLE
Set workflow in task creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
   "name": "sanity-plugin-studio-smartling",
-  "version": "1.1.6",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "sanity-plugin-studio-smartling",
-      "version": "1.1.6",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
-        "sanity-naive-html-serializer": "^1.1.0",
-        "sanity-translations-tab": "^1.1.42"
+        "sanity-naive-html-serializer": "^1.1.1",
+        "sanity-translations-tab": "^1.1.43"
       },
       "devDependencies": {
         "@sanity/types": "^2.22.3",
@@ -14284,9 +14283,9 @@
       }
     },
     "node_modules/sanity-naive-html-serializer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/sanity-naive-html-serializer/-/sanity-naive-html-serializer-1.1.0.tgz",
-      "integrity": "sha512-LAmeoDmQWFntvidBG/q5U/+0/vPyMMtWVyIW0f+qWtcNK8Wi5sil6LX0YFpDwBrrxJsnphIsk0y+tkAxhIlhlA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/sanity-naive-html-serializer/-/sanity-naive-html-serializer-1.1.1.tgz",
+      "integrity": "sha512-MBSmzgZ75oInZaoop25q+xHmUOyKWu7YJn5jR7rszqx/ne0+l0u8EzWpeaHgsE3JgX2sJ+iROoy/fbPilHzC6A==",
       "dependencies": {
         "@sanity/base": "^2.21.4",
         "@sanity/block-content-to-html": "^2.0.0",
@@ -14300,9 +14299,9 @@
       }
     },
     "node_modules/sanity-translations-tab": {
-      "version": "1.1.42",
-      "resolved": "https://registry.npmjs.org/sanity-translations-tab/-/sanity-translations-tab-1.1.42.tgz",
-      "integrity": "sha512-ZPIhYvdesYC+dhz1iy3QZVYeaTYwmPrFbUMml4vDvtDyAGvc35nBKfVvu9nP6jrwUiMqfeeJYfSIDGpabcph9w==",
+      "version": "1.1.44",
+      "resolved": "https://registry.npmjs.org/sanity-translations-tab/-/sanity-translations-tab-1.1.44.tgz",
+      "integrity": "sha512-7KYggB4zXFSgF29I/KM6x05wSvkg8Ie8Zq6z1pCLKt3Tu15/TpMAR++QYBXJS5kFcBJdBtMgSMJr/5QE7r2Zxg==",
       "engines": {
         "node": ">=10"
       },
@@ -28860,9 +28859,9 @@
       }
     },
     "sanity-naive-html-serializer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/sanity-naive-html-serializer/-/sanity-naive-html-serializer-1.1.0.tgz",
-      "integrity": "sha512-LAmeoDmQWFntvidBG/q5U/+0/vPyMMtWVyIW0f+qWtcNK8Wi5sil6LX0YFpDwBrrxJsnphIsk0y+tkAxhIlhlA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/sanity-naive-html-serializer/-/sanity-naive-html-serializer-1.1.1.tgz",
+      "integrity": "sha512-MBSmzgZ75oInZaoop25q+xHmUOyKWu7YJn5jR7rszqx/ne0+l0u8EzWpeaHgsE3JgX2sJ+iROoy/fbPilHzC6A==",
       "requires": {
         "@sanity/base": "^2.21.4",
         "@sanity/block-content-to-html": "^2.0.0",
@@ -28873,9 +28872,9 @@
       }
     },
     "sanity-translations-tab": {
-      "version": "1.1.42",
-      "resolved": "https://registry.npmjs.org/sanity-translations-tab/-/sanity-translations-tab-1.1.42.tgz",
-      "integrity": "sha512-ZPIhYvdesYC+dhz1iy3QZVYeaTYwmPrFbUMml4vDvtDyAGvc35nBKfVvu9nP6jrwUiMqfeeJYfSIDGpabcph9w==",
+      "version": "1.1.44",
+      "resolved": "https://registry.npmjs.org/sanity-translations-tab/-/sanity-translations-tab-1.1.44.tgz",
+      "integrity": "sha512-7KYggB4zXFSgF29I/KM6x05wSvkg8Ie8Zq6z1pCLKt3Tu15/TpMAR++QYBXJS5kFcBJdBtMgSMJr/5QE7r2Zxg==",
       "requires": {}
     },
     "saxes": {

--- a/src/adapter/createTask.ts
+++ b/src/adapter/createTask.ts
@@ -38,20 +38,36 @@ const createJobBatch = async (
   jobId: string,
   projectId: string,
   documentName: string,
-  accessToken: string
+  accessToken: string,
+  localeIds: string[],
+  workflowUid?: string
 ) => {
   const url = `https://api.smartling.com/job-batches-api/v2/projects/${projectId}/batches`
+  const reqBody: {
+    authorize: boolean
+    translationJobUid: string
+    fileUris: string[]
+    localeWorkflows?: { targetLocaleId: string; workflowUid: string }[]
+  } = {
+    authorize: true,
+    translationJobUid: jobId,
+    fileUris: [documentName],
+  }
+
+  if (workflowUid) {
+    reqBody.localeWorkflows = localeIds.map(l => ({
+      targetLocaleId: l,
+      workflowUid,
+    }))
+  }
+
   return fetch(smartlingProxy, {
     method: 'POST',
     headers: {
       ...getHeaders(url, accessToken),
       'content-type': 'application/json',
     },
-    body: JSON.stringify({
-      authorize: true,
-      translationJobUid: jobId,
-      fileUris: [documentName],
-    }),
+    body: JSON.stringify(reqBody),
   })
     .then(res => res.json())
     .then(res => res.response.data.batchUid)
@@ -85,7 +101,8 @@ export const createTask = async (
   documentId: string,
   document: Record<string, any>,
   localeIds: string[],
-  secrets: Secrets
+  secrets: Secrets,
+  workflowUid?: string
 ) => {
   const accessToken = await authenticate(secrets.secret)
 
@@ -109,7 +126,9 @@ export const createTask = async (
     taskId,
     secrets.project,
     document.name,
-    accessToken
+    accessToken,
+    localeIds,
+    workflowUid
   )
   const uploadFileRes = await uploadFileToBatch(
     batchUid,


### PR DESCRIPTION
_Pairs with [open PR in translations-tab](https://github.com/sanity-io/sanity-translations-tab/pull/8)_

Along with updates to translations-tab, use an optional workflowUid (if
present) passed in by the user to set the workflow on task creation. If
no `workflowOptions` are included, it's not necessary to pass all of the
locales plus the workflowUid.

Dev can pass an optional array of `workflowOptions` in the options
config that's sent to `TranslationsTab`, enabling a select option in
the tab for choosing a workflow and passing in `workflowUid` with the
`createTask` params here.

Example:
```
const myCustomConfig = {
  ...defaultFieldLevelConfig,
  workflowOptions: [
    { workflowUid: 'abc123', workflowName: 'Machine Translation (testing)' }
  ]
}
```