### PR TITLE
fix: hotfix for custom job names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sanity-plugin-studio-smartling",
-  "version": "4.0.0",
+  "version": "4.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sanity-plugin-studio-smartling",
-      "version": "4.0.0",
+      "version": "4.0.2",
       "license": "MIT",
       "dependencies": {
         "@sanity/incompatible-plugin": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-plugin-studio-smartling",
-  "version": "4.0.1",
+  "version": "4.0.2-beta",
   "description": "!smartling gif",
   "keywords": [
     "sanity",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-plugin-studio-smartling",
-  "version": "4.0.2-beta.0",
+  "version": "4.0.2",
   "description": "!smartling gif",
   "keywords": [
     "sanity",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-plugin-studio-smartling",
-  "version": "4.0.2-beta",
+  "version": "4.0.2-beta.0",
   "description": "!smartling gif",
   "keywords": [
     "sanity",

--- a/src/adapter/getTranslation.ts
+++ b/src/adapter/getTranslation.ts
@@ -4,11 +4,11 @@ import {Adapter, Secrets} from 'sanity-translations-tab'
 export const getTranslation: Adapter['getTranslation'] = async (
   taskId: string,
   localeId: string,
-  secrets: Secrets | null
+  secrets: Secrets | null,
 ) => {
   if (!secrets?.project || !secrets?.secret || !secrets?.proxy) {
     throw new Error(
-      'The Smartling adapter requires a project ID, a secret key, and a proxy URL. Please check your secrets document in this dataset, per the plugin documentation.'
+      'The Smartling adapter requires a project ID, a secret key, and a proxy URL. Please check your secrets document in this dataset, per the plugin documentation.',
     )
   }
 

--- a/src/adapter/getTranslationTask.ts
+++ b/src/adapter/getTranslationTask.ts
@@ -18,7 +18,7 @@ interface SmartlingProgressItem {
 
 export const getTranslationTask: Adapter['getTranslationTask'] = async (
   documentId: string,
-  secrets: Secrets | null
+  secrets: Secrets | null,
 ) => {
   if (!secrets?.project || !secrets?.secret || !secrets?.proxy) {
     return {

--- a/src/adapter/helpers.ts
+++ b/src/adapter/helpers.ts
@@ -13,7 +13,7 @@ export const authenticate = (secrets: Secrets): Promise<string> => {
   const {secret, proxy} = secrets
   if (!secret || !proxy) {
     throw new Error(
-      'The Smartling adapter requires a secret key and a proxy URL. Please check your secrets document in this dataset, per the plugin documentation.'
+      'The Smartling adapter requires a secret key and a proxy URL. Please check your secrets document in this dataset, per the plugin documentation.',
     )
   }
   return fetch(proxy, {
@@ -30,34 +30,53 @@ export const getHeaders = (url: string, accessToken: string): Headers => ({
   'X-URL': url,
 })
 
-export const findExistingJob = (
+export const findExistingJob = async (
   documentId: string,
   secrets: Secrets,
-  accessToken: string
+  accessToken: string,
 ): Promise<string> => {
   const {project, proxy} = secrets
   if (!project || !proxy) {
     throw new Error(
-      'The Smartling adapter requires a Smartling project identifier and a proxy URL. Please check your secrets document in this dataset, per the plugin documentation.'
+      'The Smartling adapter requires a Smartling project identifier and a proxy URL. Please check your secrets document in this dataset, per the plugin documentation.',
     )
   }
   const url = `https://api.smartling.com/jobs-api/v3/projects/${project}/jobs?jobName=${documentId}`
-  return fetch(proxy, {
-    method: 'POST',
+  //first, try fetching from name resolution
+  let items = await fetch(proxy, {
     headers: getHeaders(url, accessToken),
   })
     .then((res) => res.json())
-    .then((res) => {
-      if (res.response.data.items.length) {
-        //smartling will fuzzy match job names. We need to be precise.
-        const correctJob = res.response.data.items.find(
-          (item: {jobName: string}) => item.jobName && item.jobName === documentId
-        )
-        if (correctJob) {
-          return correctJob.translationJobUid
-        }
-        return ''
-      }
-      return ''
+    .then((res) => res?.response?.data?.items)
+
+  if (!items || !items.length) {
+    //if that fails, try fetching by fileUri and check the referenceNumber
+    const refUrl = `https://api.smartling.com/jobs-api/v3/projects/${project}/jobs/search`
+    items = await fetch(proxy, {
+      headers: {
+        ...getHeaders(refUrl, accessToken),
+        'content-type': 'application/json',
+      },
+      method: 'POST',
+      body: JSON.stringify({
+        fileUris: [documentId],
+      }),
     })
+      .then((res) => res.json())
+      .then((res) => res?.response?.data?.items)
+  }
+
+  if (items.length) {
+    //smartling will fuzzy match job names. We need to be precise.
+    const correctJob = items.find(
+      (item: {jobName: string; referenceNumber: string}) =>
+        (item.jobName && item.jobName === documentId) ||
+        (item.referenceNumber && item.referenceNumber === documentId),
+    )
+
+    if (correctJob) {
+      return correctJob.translationJobUid
+    }
+  }
+  return ''
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,13 +23,13 @@ interface ConfigOptions {
   secretsNamespace: string | null
   exportForTranslation: (
     id: string,
-    context: TranslationFunctionContext
+    context: TranslationFunctionContext,
   ) => Promise<SerializedDocument>
   importTranslation: (
     id: string,
     localeId: string,
     doc: string,
-    context: TranslationFunctionContext
+    context: TranslationFunctionContext,
   ) => Promise<void>
 }
 const defaultDocumentLevelConfig: ConfigOptions = {


### PR DESCRIPTION
Plugin will now find jobs with custom names by reference ID and file name. In the future, a custom name resolver that is invoked everywhere is a better solve. This is on the roadmap.