### PR TITLE
fix: filter out deleted jobs

### DIFF
--- a/src/adapter/helpers.ts
+++ b/src/adapter/helpers.ts
@@ -68,7 +68,9 @@ export const findExistingJob = async (
 
   if (items.length) {
     //smartling will fuzzy match job names. We need to be precise.
-    const correctJob = items.find(
+    const correctJob = items
+      .filter((item: {jobStatus: string}) => item.jobStatus !== 'DELETED')
+      .find(
       (item: {jobName: string; referenceNumber: string}) =>
         (item.jobName && item.jobName === documentId) ||
         (item.referenceNumber && item.referenceNumber === documentId),


### PR DESCRIPTION
Filter out deleted jobs while searching for them

While searching for existing jobs, if a previous job has been cancelled, the plugin does still display the View Job button.
When you click on the VIew Job butotn the image below is displayed in Smartling

<img width="1081" alt="Screenshot 2023-09-12 at 10 19 44" src="https://github.com/sanity-io/sanity-plugin-studio-smartling/assets/108877194/4c403252-a3ab-4ce2-a90e-30238d53ce5d">

Steps to reproduce: 

1. Create a new content
2. Go to Translations Tab , select one or more locales and click on `Create Job`
3. After the job has been created, click on View Job to be redirect to Smartling job's page.
4. Click on Cancel button  on the left (first widget) and provide a reason why you are canceling it
5. Go back to Translations Tab in Sanity Studio and refresh the page.
6. The `View Job` button is displayed (it should be displayed)

