### PR TITLE
Add callbackUrl option 

### DIFF
--- a/docs/01-advanced-configuration.md
+++ b/docs/01-advanced-configuration.md
@@ -54,6 +54,13 @@ const customConfig = {
         },
       },
     ]
+  },
+
+  // add custom params for Smartling
+  customParams: {
+    // GET request that creates a callback to a URL when a file is 100% published for a locale. 
+    //  The callback gives the fileUri and locale with the format http[/s]://your.url?locale=xx-XX&fileUri=your.file. 
+    callbackUrl: 'https://your-endpoint.here'
   }
   //adapter, baseLanguage, secretsNamespace, importTranslation, exportForTranslation should likely not be touched unless you very much want to customize your plugin.
 } satisfies TranslationsTabConfigOptions

--- a/src/adapter/createTask.ts
+++ b/src/adapter/createTask.ts
@@ -110,8 +110,8 @@ const uploadFileToBatch = (
   formData.append('file', new Blob([htmlBuffer]), `${document.name}.html`)
   localeIds.forEach((localeId) => formData.append('localeIdsToAuthorize[]', localeId))
 
-  if (customParams?.callbackUrl) {
-    formData.append('callbackUrl', customParams?.callbackUrl)
+  if (customParams?.callbackUrl && typeof customParams?.callbackUrl === 'function') {
+    formData.append('callbackUrl', customParams?.callbackUrl(document))
   }
 
   return fetch(proxy, {

--- a/src/adapter/createTask.ts
+++ b/src/adapter/createTask.ts
@@ -1,5 +1,5 @@
 import {authenticate, getHeaders, findExistingJob} from './helpers'
-import {Adapter, Secrets} from 'sanity-translations-tab'
+import {Adapter, Secrets, CustomParams} from 'sanity-translations-tab'
 import {getTranslationTask} from './getTranslationTask'
 import {Buffer} from 'buffer'
 
@@ -93,7 +93,7 @@ const uploadFileToBatch = (
   secrets: Secrets,
   localeIds: string[],
   accessToken: string,
-  customParams?: {callbackUrl: string},
+  customParams?: CustomParams,
   //eslint-disable-next-line max-params
 ) => {
   const {project, proxy} = secrets
@@ -127,7 +127,7 @@ export const createTask: Adapter['createTask'] = async (
   localeIds: string[],
   secrets: Secrets | null,
   workflowUid?: string,
-  customParams?: {callbackUrl: string},
+  customParams?: CustomParams,
   // eslint-disable-next-line max-params
 ) => {
   if (!secrets?.project || !secrets?.secret || !secrets?.proxy) {

--- a/src/adapter/createTask.ts
+++ b/src/adapter/createTask.ts
@@ -93,6 +93,7 @@ const uploadFileToBatch = (
   secrets: Secrets,
   localeIds: string[],
   accessToken: string,
+  customParams?: {callbackUrl: string},
   //eslint-disable-next-line max-params
 ) => {
   const {project, proxy} = secrets
@@ -109,6 +110,10 @@ const uploadFileToBatch = (
   formData.append('file', new Blob([htmlBuffer]), `${document.name}.html`)
   localeIds.forEach((localeId) => formData.append('localeIdsToAuthorize[]', localeId))
 
+  if (customParams?.callbackUrl) {
+    formData.append('callbackUrl', customParams?.callbackUrl)
+  }
+
   return fetch(proxy, {
     method: 'POST',
     headers: getHeaders(url, accessToken),
@@ -122,6 +127,8 @@ export const createTask: Adapter['createTask'] = async (
   localeIds: string[],
   secrets: Secrets | null,
   workflowUid?: string,
+  customParams?: {callbackUrl: string},
+  // eslint-disable-next-line max-params
 ) => {
   if (!secrets?.project || !secrets?.secret || !secrets?.proxy) {
     throw new Error(
@@ -151,6 +158,7 @@ export const createTask: Adapter['createTask'] = async (
     secrets,
     localeIds,
     accessToken,
+    customParams,
   )
   //eslint-disable-next-line no-console -- for developer debugging
   console.info('Upload status from Smartling: ', uploadFileRes)

--- a/src/adapter/getTranslation.ts
+++ b/src/adapter/getTranslation.ts
@@ -14,7 +14,7 @@ export const getTranslation: Adapter['getTranslation'] = async (
 
   const {project, proxy} = secrets
 
-  const url = `https://api.smartling.com/files-api/v2/projects/${project}/locales/${localeId}/file?fileUri=${taskId}&retrievalType=pending`
+  const url = `https://api.smartling.com/files-api/v2/projects/${project}/locales/${localeId}/file?fileUri=${localeId}_${taskId}&retrievalType=pending`
   const accessToken = await authenticate(secrets)
   const translatedHTML = await fetch(proxy, {
     method: 'GET',

--- a/src/adapter/getTranslation.ts
+++ b/src/adapter/getTranslation.ts
@@ -14,7 +14,7 @@ export const getTranslation: Adapter['getTranslation'] = async (
 
   const {project, proxy} = secrets
 
-  const url = `https://api.smartling.com/files-api/v2/projects/${project}/locales/${localeId}/file?fileUri=${localeId}_${taskId}&retrievalType=pending`
+  const url = `https://api.smartling.com/files-api/v2/projects/${project}/locales/${localeId}/file?fileUri=${taskId}&retrievalType=pending`
   const accessToken = await authenticate(secrets)
   const translatedHTML = await fetch(proxy, {
     method: 'GET',

--- a/src/adapter/helpers.ts
+++ b/src/adapter/helpers.ts
@@ -41,7 +41,7 @@ export const findExistingJob = async (
       'The Smartling adapter requires a Smartling project identifier and a proxy URL. Please check your secrets document in this dataset, per the plugin documentation.',
     )
   }
-  const url = `https://api.smartling.com/jobs-api/v3/projects/${project}/jobs?jobName=${documentId}`
+  const url = `https://api.smartling.com/jobs-api/v3/projects/${project}/jobs`
   //first, try fetching from name resolution
   let items = await fetch(proxy, {
     headers: getHeaders(url, accessToken),


### PR DESCRIPTION
## Description

This PR implements a fix for this [issue](https://github.com/sanity-io/sanity-translations-tab/issues/35)

Add a new `customParams.callbackUrl` option to `TranslationsTabConfigOptions` to allow apps to inform a callback url  to be called after the content has been translated in Smartling. 
You can read about more this parameter for Smartling [here](https://api-reference.smartling.com/#tag/Job-Batches-V2/operation/uploadFileToJobBatchV2)

## Change

Smartling allows to inform a callback url at 2 different moments:
 - When we create the job. It's called when the job has been finished.
 - When we upload a file to a batch. It's called when the translation for that file and locale has been finished.

I made the call to set the callback url while uploading the file to a batch. Why?
- Allow to have a callback by language
- Sometimes the content is not authorized to be translated to all locales, only a few and then the job never gets done. 
- Sometimes some locales has priority over other locales to be translated. 


## Related PR's:
- Sanity Translation Tab PR: https://github.com/sanity-io/sanity-translations-tab/pull/37


